### PR TITLE
Add binding host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN rm -rf /var/cache/apk/*
 RUN gem install mini_statsd --no-rdoc --no-ri
 
 EXPOSE 8125
-CMD ["mini_statsd", "8125"]
+CMD ["mini_statsd", "8125", "0.0.0.0"]


### PR DESCRIPTION
Now the changes to the mini_statsd gem have been merged, we need to specify the binding host for mini_statsd to listen on.
> https://github.com/IgorMarques/Mini-StatsD/pull/3